### PR TITLE
Zub/enable cors for wordpress plugin

### DIFF
--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -36,6 +36,7 @@ INSTALLED_APPS = [
 
 THIRD_PARTY_APPS = [
     'release_util',
+    'corsheaders',
     'rest_framework',
     'rest_framework_swagger',
     'social_django',
@@ -79,6 +80,7 @@ INSTALLED_APPS += ['haystack']
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/course_discovery/settings/devstack.py
+++ b/course_discovery/settings/devstack.py
@@ -4,6 +4,12 @@ from course_discovery.settings.production import *
 
 DEBUG = True
 
+CORS_ORIGIN_ALLOW_ALL = True
+CORS_ALLOW_CREDENTIALS = True
+CORS_ORIGIN_WHITELIST = (
+    'localhost:8888',
+)
+
 # Docker does not support the syslog socket at /dev/log. Rely on the console.
 LOGGING['handlers']['local'] = {
     'class': 'logging.NullHandler',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 beautifulsoup4==4.5.1
 boto==2.42.0
 cryptography==1.7.1
-django==1.11.11
+django==1.11.15
 django-autocomplete-light==3.1.8
 django-choices==1.4.3
 django-compressor==2.1.1


### PR DESCRIPTION
Enable `CORS` headers for our modified eduNEXT Wordpress plugin.
Wordpress site running at http://localhost:8888